### PR TITLE
Fix ssl wrong version number errors

### DIFF
--- a/storage/redis.go
+++ b/storage/redis.go
@@ -13,10 +13,15 @@ import (
 )
 
 type Config struct {
-	Endpoint string `json:"endpoint"`
-	Password string `json:"password"`
-	Database int64  `json:"database"`
-	PoolSize int    `json:"poolSize"`
+	Endpoint      string   `json:"endpoint"`
+	Password      string   `json:"password"`
+	Database      int64    `json:"database"`
+	PoolSize      int      `json:"poolSize"`
+	SentinelAddrs []string `json:"sentinelAddrs"`
+	MasterName    string   `json:"masterName"`
+	// TLS settings
+	TLS           bool     `json:"tls"`
+	TLSSkipVerify bool     `json:"tlsSkipVerify"`
 }
 
 type RedisClient struct {


### PR DESCRIPTION
Add TLS configuration options to the Redis client.

Enable secure connections to TLS-enabled Valkey/Redis servers, resolving "wrong version number" errors from plain-text connections to TLS-only ports.

---

[Open in Web](https://cursor.com/agents?id=bc-b9bfbf8d-3fd2-496f-b04c-beb9017ae284) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-b9bfbf8d-3fd2-496f-b04c-beb9017ae284)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)